### PR TITLE
Moving inline styling to stylesheets

### DIFF
--- a/app/assets/stylesheets/global.css
+++ b/app/assets/stylesheets/global.css
@@ -1,12 +1,2 @@
-
-
-/* Lic Logo Sizing */
-.lic-logo {
-    max-height: 140px;
-    max-width: 210px;
-    object-fit: contain;
-    display: block;
-    padding-top: 20px;
-  }
-  
+/* App global styling */
   

--- a/app/assets/stylesheets/lics_index_table.css
+++ b/app/assets/stylesheets/lics_index_table.css
@@ -1,0 +1,24 @@
+/* Styling the LICs table on the index action view template */
+
+.lics-index-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 40px;
+}
+  
+.lics-index-table th, .lics-index-table td {
+    border: 1px solid lightgrey;
+}
+  
+.lics-index-table-link {
+    text-decoration: none;
+    color: inherit;
+}
+  
+.lics-index-table-hover-effect:hover {
+    background-color: #f0f0f0;
+}
+
+.lics-index-table-hover-effect:hover .lics-index-table-link {
+    text-decoration: underline;
+}

--- a/app/assets/stylesheets/lics_show_page.css
+++ b/app/assets/stylesheets/lics_show_page.css
@@ -1,0 +1,9 @@
+/* Styling specifcally for the LICs show action view template */
+
+.lic-logo {
+    max-height: 140px;
+    max-width: 210px;
+    object-fit: contain;
+    display: block;
+    padding-top: 20px;
+}

--- a/app/views/lics/index.html.erb
+++ b/app/views/lics/index.html.erb
@@ -1,26 +1,34 @@
+<!-- Dedicated stylesheet for the LICs Index table -->
+<%= stylesheet_link_tag 'lics_index_table' %>
+
+<!-- Header -->
 <h1>Listed Investment Companies in Australia</h1>
 <p>The table below shows the top 30 Listed Investment Companies (by size) listed on the ASX.</p>
 
-<table style="width: 100%; border-collapse: collapse; margin-bottom: 40px;">
+
+<!-- LICs Index Table -->
+<table class="lics-index-table">
   <thead>
-    <tr style="border: 1px solid lightgrey;">
-      <th style="border: 1px solid lightgrey;">Name</th>
-      <th style="border: 1px solid lightgrey;">Ticker</th>
-      <th style="border: 1px solid lightgrey;">Size</th>
-      <th style="border: 1px solid lightgrey;">Started</th>
-      <th style="border: 1px solid lightgrey;">Focus</th>
-      <th style="border: 1px solid lightgrey;">Cost</th>
+    <tr>
+      <th>Name</th>
+      <th>Ticker</th>
+      <th>Size</th>
+      <th>Started</th>
+      <th>Focus</th>
+      <th>Cost</th>
     </tr>
   </thead>
   <tbody>
     <% @lics.each do |lic| %>
-      <tr style="border: 1px solid lightgrey;">
-        <td style="border: 1px solid lightgrey;"><%= link_to lic.name, listed_investment_company_path(lic), style: "text-decoration: none; color: inherit;" %></td>
-        <td style="border: 1px solid lightgrey;"><%= lic.ticker %></td>
-        <td style="border: 1px solid lightgrey;"><%= format_market_cap(lic.market_cap) %></td>
-        <td style="border: 1px solid lightgrey;"><%= lic.listing_year %></td>
-        <td style="border: 1px solid lightgrey;"><%= lic.investment_focus %></td>
-        <td style="border: 1px solid lightgrey;"><%= sprintf("%.2f", lic.calculated_mer) %>%</td>
+      <tr>
+        <td class="lics-index-table-hover-effect">
+          <%= link_to lic.name, listed_investment_company_path(lic), class: "lics-index-table-link" %>
+        </td>
+        <td><%= lic.ticker %></td>
+        <td><%= format_market_cap(lic.market_cap) %></td>
+        <td><%= lic.listing_year %></td>
+        <td><%= lic.investment_focus %></td>
+        <td><%= sprintf("%.2f", lic.calculated_mer) %>%</td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/lics/show.html.erb
+++ b/app/views/lics/show.html.erb
@@ -1,3 +1,6 @@
+<!-- Dedicated stylesheet for this Show template -->
+<%= stylesheet_link_tag 'lics_show_page' %>
+
 <!-- SEO details -->
 <% content_for :title do %>
   <%= @lic.name %> (<%= @lic.ticker %>) | Listed Landscape


### PR DESCRIPTION
Pulled out inline styling in the HTML ERB view templates to dedicated stylesheets.

Also added a hover effect when clicking the LIC Name link in the Index view template.